### PR TITLE
Cards solo si hay menús guardados

### DIFF
--- a/migrations/versions/14c3b8323c6b_.py
+++ b/migrations/versions/14c3b8323c6b_.py
@@ -1,8 +1,8 @@
 """empty message
 
-Revision ID: aba485d41bf8
+Revision ID: 14c3b8323c6b
 Revises: 
-Create Date: 2021-04-17 14:56:43.908593
+Create Date: 2021-04-17 19:56:40.002514
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = 'aba485d41bf8'
+revision = '14c3b8323c6b'
 down_revision = None
 branch_labels = None
 depends_on = None

--- a/migrations/versions/90eab4f872ae_.py
+++ b/migrations/versions/90eab4f872ae_.py
@@ -1,8 +1,8 @@
 """empty message
 
-Revision ID: 14c3b8323c6b
+Revision ID: 90eab4f872ae
 Revises: 
-Create Date: 2021-04-17 19:56:40.002514
+Create Date: 2021-04-18 13:33:39.614738
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '14c3b8323c6b'
+revision = '90eab4f872ae'
 down_revision = None
 branch_labels = None
 depends_on = None

--- a/src/front/js/component/login.js
+++ b/src/front/js/component/login.js
@@ -46,6 +46,7 @@ const SignInForm = props => {
 						{ autoClose: 6000 }
 					);
 					history.push("/home");
+					actions.getAllMenusCount();
 				}
 			})
 			.catch(error => {

--- a/src/front/js/component/profile.js
+++ b/src/front/js/component/profile.js
@@ -104,7 +104,7 @@ export const Profile = props => {
 
 	let history = useHistory();
 	if (!actions.isUserAuthenticated()) {
-		toast.info("Favor inicia sesión!");
+		toast("Favor inicia sesión!");
 		history.push("/profile");
 		console.log(store.accessToken);
 	}

--- a/src/front/js/component/weekplan.js
+++ b/src/front/js/component/weekplan.js
@@ -11,7 +11,7 @@ export const Weekplan = props => {
 
 	const handleSubmit = () => {
 		actions.addNewWeeklyMenu(titleMenu); //Trigger para enviar el JSON a /api/new_weekly_menu
-		toast.success("You saved your menu!");
+		toast("You saved your menu!");
 		store.thereismenus = "Y";
 	};
 

--- a/src/front/js/component/weekplan.js
+++ b/src/front/js/component/weekplan.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { Context } from "../store/appContext";
 import { Tab, Row, Col, Nav, Button, FormControl, Form } from "react-bootstrap";
 import { DailyPlan } from "./daily_plan";
+import { toast, ToastContainer } from "react-toastify";
 
 export const Weekplan = props => {
 	const { store, actions } = useContext(Context);
@@ -11,6 +12,7 @@ export const Weekplan = props => {
 	const handleSubmit = () => {
 		actions.addNewWeeklyMenu(titleMenu); //Trigger para enviar el JSON a /api/new_weekly_menu
 		actions.getAllMenusCount();
+		toast.success("You saved your menu!");
 	};
 
 	const handleInputChange = e => {

--- a/src/front/js/component/weekplan.js
+++ b/src/front/js/component/weekplan.js
@@ -12,6 +12,7 @@ export const Weekplan = props => {
 	const handleSubmit = () => {
 		actions.addNewWeeklyMenu(titleMenu); //Trigger para enviar el JSON a /api/new_weekly_menu
 		actions.getAllMenusCount();
+		store.thereismenus = "Y";
 		toast.success("You saved your menu!");
 	};
 

--- a/src/front/js/component/weekplan.js
+++ b/src/front/js/component/weekplan.js
@@ -11,9 +11,8 @@ export const Weekplan = props => {
 
 	const handleSubmit = () => {
 		actions.addNewWeeklyMenu(titleMenu); //Trigger para enviar el JSON a /api/new_weekly_menu
-		actions.getAllMenusCount();
-		store.thereismenus = "Y";
 		toast.success("You saved your menu!");
+		store.thereismenus = "Y";
 	};
 
 	const handleInputChange = e => {

--- a/src/front/js/component/weekplan.js
+++ b/src/front/js/component/weekplan.js
@@ -10,6 +10,7 @@ export const Weekplan = props => {
 
 	const handleSubmit = () => {
 		actions.addNewWeeklyMenu(titleMenu); //Trigger para enviar el JSON a /api/new_weekly_menu
+		actions.getAllMenusCount();
 	};
 
 	const handleInputChange = e => {

--- a/src/front/js/pages/userprofile.js
+++ b/src/front/js/pages/userprofile.js
@@ -45,7 +45,7 @@ export const ProfileCard = props => {
 			.then(response => response.json())
 			.then(result => {
 				console.log(result);
-				toast.success("You saved your changes successfully!");
+				toast("You saved your changes successfully!");
 				actions.setCurrentUser(result);
 			})
 			.catch(error => console.log("error", error));
@@ -119,7 +119,7 @@ export const Userprofile = props => {
 	const { store, actions } = useContext(Context);
 	let history = useHistory();
 	if (!actions.isUserAuthenticated()) {
-		toast.info("Please, login!");
+		toast("Please, login!");
 		history.push("/");
 	}
 

--- a/src/front/js/pages/weeks.js
+++ b/src/front/js/pages/weeks.js
@@ -122,15 +122,35 @@ export const AllWeeks = () => {
 		return <RecipeCard key={index} id={item.id} title={item.title} />;
 	});
 
-	return (
-		<div className="container-fluid">
-			<div className="page-container d-flex">
-				<div className="card-container d-flex justify-content-center mx-auto">
-					<div className="row all-cards ">{dayMenu ? dayMenu : ""}</div>
+	console.log("there is menus (weeks)?", store.thereismenus);
+	if (store.thereismenus == "Y") {
+		return (
+			<div className="container-fluid">
+				<div className="page-container d-flex">
+					<div className="card-container d-flex justify-content-center mx-auto">
+						<div className="row all-cards ">{dayMenu ? dayMenu : ""}</div>
+					</div>
 				</div>
 			</div>
-		</div>
-	);
+		);
+	} else {
+		return (
+			<div className="container-fluid">
+				<div className="page-container d-flex flex-column justify-content-center mx-auto pt-5">
+					<div className="card-container mx-auto ">
+						<p className="justify-content-center mx-auto ">
+							<h3>{"You still don't have weekly menus saved"}</h3>
+						</p>
+						<div className="d-flex mx-auto justify-content-center ">
+							<button className="green-button btn p-2" id="button-0menus">
+								<Link to="/new_week">New week</Link>
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		);
+	}
 };
 
 RecipeCard.propTypes = {

--- a/src/front/js/pages/weeks.js
+++ b/src/front/js/pages/weeks.js
@@ -74,6 +74,7 @@ export const RecipeCard = props => {
 				toast.info("You have deleted one of your weekly menus");
 				history.push("/home");
 				history.push("/weeks");
+				actions.getAllMenusCount();
 			})
 			.catch(error => error);
 	};

--- a/src/front/js/store/appContext.js
+++ b/src/front/js/store/appContext.js
@@ -23,6 +23,7 @@ const injectContext = PassedComponent => {
 
 		useEffect(() => {
 			state.actions.getWelcomeMessage();
+			state.actions.getAllMenusCount();
 		}, []);
 
 		// useEffect(

--- a/src/front/js/store/flux.js
+++ b/src/front/js/store/flux.js
@@ -34,7 +34,10 @@ const getState = ({ getStore, getActions, setStore }) => {
 				"http://www.edamam.com/ontologies/edamam.owl#recipe_e2044086d8346319d6c46b4273edf586",
 				"http://www.edamam.com/ontologies/edamam.owl#recipe_62f902aa94f7c6040c736bb8550a107f",
 				"http://www.edamam.com/ontologies/edamam.owl#recipe_e2044086d8346319d6c46b4273edf586"
-			]
+			],
+			allmenus: null,
+			countmenus: [],
+			thereismenus: ""
 		}, //close store
 
 		actions: {
@@ -227,6 +230,31 @@ const getState = ({ getStore, getActions, setStore }) => {
 					.then(response => response.json())
 					.then(result => console.log(result))
 					.catch(error => console.log("Recipes are not available now", error));
+			},
+			getAllMenusCount: () => {
+				let store = getStore();
+				var requestOptions = {
+					method: "GET",
+					headers: {
+						Authorization: "Bearer " + localStorage.getItem("accessToken"),
+						"Content-Type": "application/json"
+					}
+				};
+
+				fetch(`${apiBaseUrl}/api/me/menus`, requestOptions)
+					.then(response => response.json())
+					.then(result => {
+						console.log("there is --> ", result.length, " menus");
+						setStore({ countmenus: result });
+						if (result.length == 0) {
+							store.thereismenus = "N";
+						} else {
+							store.thereismenus = "Y";
+						}
+					})
+					.catch(error => console.log("Menus are not available now", error));
+
+				console.log("there is menus? ", store.thereismenus);
 			}
 		}
 	};

--- a/src/front/js/store/flux.js
+++ b/src/front/js/store/flux.js
@@ -246,10 +246,10 @@ const getState = ({ getStore, getActions, setStore }) => {
 					.then(result => {
 						console.log("there is --> ", result.length, " menus");
 						setStore({ countmenus: result });
-						if (result.length == 0) {
-							store.thereismenus = "N";
-						} else {
+						if (result.length != 0) {
 							store.thereismenus = "Y";
+						} else {
+							store.thereismenus = "N";
 						}
 					})
 					.catch(error => console.log("Menus are not available now", error));


### PR DESCRIPTION
Si no hay menús guardados sale un aviso y un enlace, en caso de tener cards te las muestra. Ello requiere de un contador en flux que revisa si tiene o no tiene menus guardados, desde que el usuario se loguea, y cuando eliminas. Cuando añades un menú incluye también la modificación de ese dato (aunque no hace el fetch para contar menús). 

Además he modificado algunos toast para que esten todos en basico